### PR TITLE
Fix join script config folder

### DIFF
--- a/join_fluxxchain.sh
+++ b/join_fluxxchain.sh
@@ -24,6 +24,7 @@ mkdir -p "$NODE_DIR"
 
 echo "🗂️ Inicializando nodo local..."
 docker run --rm -v "$NODE_DIR":$NODE_HOME "$DOCKER_IMAGE" simd init "$NODE_MONIKER" --chain-id "$CHAIN_ID" --home "$NODE_HOME"
+mkdir -p "$NODE_DIR/config"
 
 echo "🌐 Descargando genesis.json..."
 curl -s -L -o "$NODE_DIR/config/genesis.json" "$GENESIS_URL"


### PR DESCRIPTION
## Summary
- ensure `join_fluxxchain.sh` creates the config directory after initialization

## Testing
- `bash -n /tmp/join_temp.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840f0d4a6a8832ca2ee147e33db5f9c